### PR TITLE
chore(playground): config smb-theme for @opentiny/vue

### DIFF
--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -1,10 +1,5 @@
 <script setup>
 import {
-  Button as TinyButton,
-  Layout as TinyLayout,
-  Row as TinyRow,
-} from '@opentiny/vue'
-import {
   iconDel,
   iconEdit,
   iconMail,

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -1,7 +1,6 @@
 import { createApp } from 'vue'
 import { createRouter, createWebHistory } from 'vue-router'
 import routes from 'virtual:generated-pages'
-import TinyVue from '@opentiny/vue'
 import App from './App.vue'
 import '@unocss/reset/tailwind.css'
 import './styles/main.css'
@@ -12,5 +11,5 @@ const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes,
 })
-app.use(router).use(TinyVue)
+app.use(router)
 app.mount('#app')

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -12,9 +12,16 @@ import autoImportPlugin from '@opentiny/unplugin-tiny-vue'
 
 export default defineConfig({
   resolve: {
-    alias: {
-      '~/': `${path.resolve(__dirname, 'src')}/`,
-    },
+    alias: [
+      {
+        find: '~/',
+        replacement: `${path.resolve(__dirname, 'src')}/`
+      },
+      {
+        find: /\@opentiny\/vue-theme\/(?!(smb))/,
+        replacement: '@opentiny/vue-theme/smb-theme/'
+      },
+    ],
   },
   define: {
     'process.env': { ...process.env },


### PR DESCRIPTION
主要变更点：
- 给 `@opentiny/vue` 增加 smb-theme 配置
- 移除没有必要的 `@opentiny/vue` 引入，因为已经配置了 `unplugin-tiny-vue` 自动导入插件