### PR TITLE
docs: update README with improved useRaf example and TypeScript syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,18 +27,20 @@ import {
   useRaf,
 } from 'lazy-js-utils'
 
-// 监听container的变化, 你不在需要const container = ref<HTMLElement>
+// 监听container的变化, 你不再需要const container = ref<HTMLElement>
 useMutationObserver('#container', (mutationsList, observer) => {
   console.log(mutationsList)
 })
 // requestAnimationFrame
 useRaf(
   (timestamp) => {
-    // 每针相隔1s执行
+    // 每帧相隔1s执行
     console.log('animationFrame', timestamp)
   },
-  1000,
-  true /* 只执行一次后被销毁 */,
+  {
+    delta: 1000,
+    autoStop: true /* 只执行一次后被销毁 */
+  }
 )
 // 注册事件
 useEventListener('#container', 'click', () => {

--- a/README_en.md
+++ b/README_en.md
@@ -19,26 +19,28 @@ At present, I have sorted out <strong>about 200</strong> commonly used functions
 
 ## &#x270B; Example
 
-```js
+```ts
 import {
-  animationFrameWrapper,
   insertElement,
   useEventListener,
   useMutationObserver,
+  useRaf,
 } from 'lazy-js-utils'
 
-// To listen for container changes, you don't need const container <HTMLElement>= ref
+// To listen for container changes, you don't need const container = ref<HTMLElement>
 useMutationObserver('#container', (mutationsList, observer) => {
   console.log(mutationsList)
 })
 // requestAnimationFrame
-animationFrameWrapper(
+useRaf(
   (timestamp) => {
-    // Each needle is executed 1s apart
+    // Executed only when at least 1s has passed between frames
     console.log('animationFrame', timestamp)
   },
-  1000,
-  true /* It is destroyed after only one execution */,
+  {
+    delta: 1000,
+    autoStop: true /* It is destroyed after only one execution */
+  }
 )
 // Register for events
 useEventListener('#container', 'click', () => {
@@ -72,7 +74,7 @@ import {
 
 [Buy me a cup of coffee](https://github.com/Simon-He95/sponsor)
 
-## GitHub 地址
+## GitHub Repository
 
 [Welcome to PR](https://github.com/Simon-He95/lazy-js-utils)
 


### PR DESCRIPTION
# Fix documentation inconsistencies

- Fixed incorrect character in Chinese README (针 → 帧)
- Updated English README to match Chinese version (animationFrameWrapper → useRaf)
- Corrected useRaf parameter format in both READMEs to use options object
- Improved translations and standardized formatting

These changes ensure documentation accurately reflects the current API implementation.